### PR TITLE
fix: double-slash URL and duplicate number in StudyPlan problem list

### DIFF
--- a/apps/web/components/StudyPlan/ProblemList.tsx
+++ b/apps/web/components/StudyPlan/ProblemList.tsx
@@ -23,11 +23,11 @@ const ProblemList = React.memo(({ problems }: ProblemListProps) => {
           <div key={problem.title}>
             <div className="flex flex-row items-center text-pretty justify-between rounded p-1 m-1 bg-muted/50">
               <Link
-                href={`${LC_HOST}/problems/${problem.slug}`}
+                href={`${LC_HOST}/problems/${problem.slug.replace(/^\/|\/$/g, "")}`}
                 target="_blank"
                 className="hover:underline"
               >
-                {problem.id}. {problem.title}
+                {problem.title}
               </Link>
               <div className="flex flex-row items-center gap-2">
                 {problem.score ? (


### PR DESCRIPTION
## Summary
- English LeetCode URLs were broken due to leading/trailing slashes in the `slug` field, producing `problems//slug` instead of `problems/slug`
- Problem titles were displaying duplicated numbers (e.g. `200. 200. 岛屿数量`) because `problem.title` already includes the number prefix

## Related Issue
Closes #93

## Changes
- `apps/web/components/StudyPlan/ProblemList.tsx`: strip slashes from `problem.slug` when constructing the href; removed redundant `{problem.id}.` prefix from the display label

## Test Plan
- [ ] Navigate to 网格图 / 单调栈 / 滑动窗口 / 字符串 / 树和二叉树 in the StudyPlan section
- [ ] Switch link language to English and verify problem links open correctly (no double slash)
- [ ] Confirm problem titles no longer show duplicate numbers